### PR TITLE
Added backward propagation, chronological backtracking, and pruning strategy

### DIFF
--- a/include/aig_dpll_solver.hpp
+++ b/include/aig_dpll_solver.hpp
@@ -22,6 +22,9 @@ class aig_dpll_solver {
         // Node evaluation status and values
         std::vector<bool> m_values;
         std::vector<bool> m_assigned;
+        std::vector<GateId> trail_node; 
+        std::vector<size_t> node_level;
+
     
     public:
         explicit aig_dpll_solver(const aig_ntk& ntk) 
@@ -39,61 +42,81 @@ class aig_dpll_solver {
             m_values[id] = val;
             m_assigned[id] = true;
         }
-    
+        
+        void assign_node(GateId id, bool val) {
+            if (m_assigned[id]) return; 
+            m_values[id] = val;
+            m_assigned[id] = true;
+            trail_node.push_back(id);
+        }
         // Unassign input node
         void unassign_input(GateId id) {
             m_assigned[id] = false;
         }
-    
-        // Evaluate node value recursively
-        bool evaluate_node(GateId id, uint32_t complement = 0) {
-            if (m_assigned[id]) return m_values[id];
-    
-            const auto& node = m_ntk.get_gates()[id];
-            
-            // Input node without assignment
-            if (node.children[0] == id && node.children[1] == id) {
-                return m_values[id];
+        // backtrack to the previous decision level
+        void backtrack() {
+            size_t node_start = node_level.back();
+            node_level.pop_back();
+            while (trail_node.size()>node_start) {
+                GateId id = trail_node.back();
+                trail_node.pop_back();
+                m_assigned[id] = false;
+                m_values[id] = false;
             }
-    
-            // Evaluate AND gate
-            bool lhs_val = evaluate_node(m_ntk.data_to_index(node.children[0]));
-            bool rhs_val = evaluate_node(m_ntk.data_to_index(node.children[1]));
-            
-            // Handle complemented edges
-            if (m_ntk.data_to_complement(node.children[0])) lhs_val = !lhs_val;
-            if (m_ntk.data_to_complement(node.children[1])) rhs_val = !rhs_val;
-            // Check complement and assign value
-            if (complement == 1) {
-                m_values[id] = !(lhs_val & rhs_val); 
-            } else {
-                m_values[id] = lhs_val & rhs_val; 
-            }
-            m_assigned[id] = true;
-            return m_values[id];
         }
-    
+        
+        //bcp
+        void bcp(GateId id){
+            const auto& n = m_ntk.get_gates()[id];
+            for(auto out_id : n.outputs){
+                const auto& out = m_ntk.get_gates()[out_id];
+                if(m_assigned[out_id]) continue;
+                GateId left_node = m_ntk.data_to_index(out.children[0]);
+                GateId right_node = m_ntk.data_to_index(out.children[1]);
+                if(m_assigned[left_node] && m_assigned[right_node]){
+                    bool left_val , right_val;
+                    if(m_ntk.data_to_complement(out.children[0])==1){
+                        left_val = !m_values[left_node];
+                    }
+                    else{
+                        left_val = m_values[left_node];
+                    }
+                    if(m_ntk.data_to_complement(out.children[1])==1){
+                        right_val = !m_values[right_node];
+                    }
+                    else{
+                        right_val = m_values[right_node];
+                    }
+                    bool out_val = left_val & right_val;
+                    assign_node(out_id,out_val);
+                    bcp(out_id);
+                }
+            }
+        }
+        
         // Recursive search for satisfying assignment
         bool search(size_t input_idx, std::vector<bool>& input_vals) {
             const auto& inputs = m_ntk.get_inputs();
-            if (input_idx == inputs.size()) {
-                clear_assignments();
-                for (size_t i = 0; i < inputs.size(); ++i) {
-                    assign_input(inputs[i], input_vals[i]);
-                }
-                
-                // Check all outputs
-                for (GateId out_id : m_ntk.get_outputs()) {
-                    bool out_val = evaluate_node(out_id >> 1, out_id & 1);
-                    if (!out_val) return false;
-                }
-                return true;
-            }
-    
+            if (input_idx == inputs.size()) return false;
             // Try both possible input values
             for (bool val : {false, true}) {
+                node_level.push_back(trail_node.size());
+                GateId input_id = inputs[input_idx];
                 input_vals[input_idx] = val;
+                assign_node(input_id, val);
+                bcp(input_id);
+                auto out_data=m_ntk.get_outputs()[0];
+                if(m_assigned[m_ntk.data_to_index(out_data)]){
+                    if((m_ntk.data_to_complement(out_data)==0)&&m_values[m_ntk.data_to_index(out_data)]) {return true;}
+                    else if((m_ntk.data_to_complement(out_data)==1)&&!m_values[m_ntk.data_to_index(out_data)]) {return true;}
+                    else {
+                        backtrack();
+                        continue;
+                    }
+                }
                 if (search(input_idx + 1, input_vals)) return true;
+
+                backtrack();
             }
             return false;
         }


### PR DESCRIPTION
This commit introduces a basic backward Boolean Constraint Propagation (BCP) mechanism and time-based backtracking strategy. After each assignment, the backward BCP propagates implications, and once certain output values are determined, further assignments can be skipped. This enables early termination and reduces unnecessary search, improving pruning efficiency.

Future work includes leveraging AND gate properties to accelerate signal propagation further, and designing variable assignment order strategies based on logical influence or circuit structure.